### PR TITLE
Add some CSS to fade out the callback progress bar

### DIFF
--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -103,7 +103,7 @@ main,
 .message-container .callback-progress {
   display: table-cell;
   width: 100%;
-  padding: 5px 0 5px 10px;
+  padding: 0 0 10px 10px;
 }
 .message-container .callback-progress-bar {
   background-image: url("/images/crowd.jpg");
@@ -115,11 +115,20 @@ main,
   height: 30px;
   transition: width 1s ease-in-out;
 }
-.message-container .callback-progress-callback {
-  display: inline-block;
+.callback-progress-bar .callback-progress-callback {
   height: 25px;
   float: right;
   margin: 5px;
+}
+.callback-progress-bar-expired {
+  height: 30px;
+}
+.callback-progress-bar-expired .callback-progress-callback {
+  display: inline-block;
+  height: 25px;
+  line-height: 25px;
+  margin: 5px 15px;
+  vertical-align: bottom;
 }
 .message-container .callback-progress-voice {
   background-image: url("/images/profile_placeholder.png");

--- a/src/callback_ui.js
+++ b/src/callback_ui.js
@@ -183,6 +183,22 @@ class CallbackProgress {
       setTimeout(() => {
         this.div.classList.add('visible');
       }, 1);
+
+      // Start the progress bar fading out.
+      setTimeout(() => {
+        const progressBar = this.div.querySelector('.callback-progress-bar');
+        progressBar.style.transition =
+            `opacity ${config.CONFIG.callback_window_ms - 1000}ms ease-in`;
+        progressBar.style.opacity = 0;
+      }, 1001);
+
+      // When the window ends, flip the progress bar style.
+      setTimeout(() => {
+        const progressBar = this.div.querySelector('.callback-progress-bar');
+        progressBar.classList.remove('callback-progress-bar');
+        progressBar.classList.add('callback-progress-bar-expired');
+        progressBar.removeAttribute('style');
+      }, config.CONFIG.callback_window_ms);
     }
 
     if (scrollToProgressBar) {


### PR DESCRIPTION
Also replace the progress bar with a less intrusive text callout once it's expired. Fixes #47.