### PR TITLE
Make the weight parameter required in config.js

### DIFF
--- a/src/callback_ui.js
+++ b/src/callback_ui.js
@@ -153,7 +153,8 @@ class CallbackProgress {
    * @param {string} callbackText The full callback to use in the progress bar.
    * @param {number} timestamp The timestamp to display, in milliseconds since
    *     epoch.
-   * @param {number} weight A multiplier to apply to the callback window size and threshold.
+   * @param {number} weight A multiplier to apply to the callback window size
+   *     and threshold.
    */
   constructor(callbackEmoji, callbackText, timestamp, weight) {
     this.id = CALLBACK_ID.next();

--- a/src/callback_ui.js
+++ b/src/callback_ui.js
@@ -153,8 +153,7 @@ class CallbackProgress {
    * @param {string} callbackText The full callback to use in the progress bar.
    * @param {number} timestamp The timestamp to display, in milliseconds since
    *     epoch.
-   * @param {number=} weight Optional, a multiplier to apply to the callback
-   *     window size and threshold.
+   * @param {number} weight A multiplier to apply to the callback window size and threshold.
    */
   constructor(callbackEmoji, callbackText, timestamp, weight) {
     this.id = CALLBACK_ID.next();

--- a/src/config.js
+++ b/src/config.js
@@ -84,31 +84,27 @@ export class Configuration {
   }
 
   /**
-   * @param {number=} weight Optional, a multiplier to apply to the returned
-   * window size.
+   * @param {number} weight A multiplier to apply to the returned window size.
    * @return {number} The amount of time in ms within which a minimum of
    * callbackThreshold() of voices need to send a callback for the app to
    * play the callback's video.
    */
-  callbackWindowMs(weight = 1) {
+  callbackWindowMs(weight) {
     return weight * this.callback_window_ms_base;
   }
 
   /**
-   * @param {number=} weight Optional, a multiplier to apply to the returned
-   * threshold.
+   * @param {number} weight A multiplier to apply to the returned threshold.
    * @return {number} The minimum number of voices that need to send a
    * callback within callbackWindowMs() for the app to play the
    * callback's video.
    */
-  callbackThreshold(weight = 1) {
-    return Math.max(
-      2,
-      weight *
-        (this.threshold_is_percentage ?
-          Math.floor(this.active_users * (this.callback_threshold_base / 100)) :
-          this.callback_threshold_base),
-    );
+  callbackThreshold(weight) {
+    let threshold = this.callback_threshold_base;
+    if (this.threshold_is_percentage) {
+      threshold = this.active_users * threshold / 100;
+    }
+    return Math.max(2, Math.floor(weight * threshold));
   }
 
   /**

--- a/src/view.js
+++ b/src/view.js
@@ -238,10 +238,11 @@ function loadCallbacks_() {
     if (callback.unsubscribeFromFirestore) {
       callback.unsubscribeFromFirestore();
     }
-    const query = window.firebase.firestore()
-                      .collection(callback.callback.getCollection())
-                      .orderBy('timestamp', 'desc')
-                      .limit(config.CONFIG.callbackThreshold(callback.callback.weight));
+    const query =
+        window.firebase.firestore()
+           .collection(callback.callback.getCollection())
+           .orderBy('timestamp', 'desc')
+           .limit(config.CONFIG.callbackThreshold(callback.callback.weight));
 
     callback.unsubscribeFromFirestore = query.onSnapshot(
         (snapshot) => {

--- a/src/view.js
+++ b/src/view.js
@@ -241,7 +241,7 @@ function loadCallbacks_() {
     const query = window.firebase.firestore()
                       .collection(callback.callback.getCollection())
                       .orderBy('timestamp', 'desc')
-                      .limit(config.CONFIG.callbackThreshold());
+                      .limit(config.CONFIG.callbackThreshold(callback.callback.weight));
 
     callback.unsubscribeFromFirestore = query.onSnapshot(
         (snapshot) => {

--- a/test/config_test.js
+++ b/test/config_test.js
@@ -48,7 +48,7 @@ describe('config', function() {
     CONFIG.active_users = 25;
     CONFIG.callback_threshold_base = 15;
     CONFIG.threshold_is_percentage = true;
-    CONFIG.callbackThreshold(2).should.equal(6);
+    CONFIG.callbackThreshold(2).should.equal(7);
   });
 
   it('returns window size in ms', function() {

--- a/test/config_test.js
+++ b/test/config_test.js
@@ -13,28 +13,28 @@ describe('config', function() {
     CONFIG.active_users = 25;
     CONFIG.callback_threshold_base = 0;
     CONFIG.threshold_is_percentage = false;
-    CONFIG.callbackThreshold().should.equal(2);
+    CONFIG.callbackThreshold(1).should.equal(2);
   });
 
   it('returns threshold when not a percentage', function() {
     CONFIG.active_users = 25;
     CONFIG.callback_threshold_base = 3;
     CONFIG.threshold_is_percentage = false;
-    CONFIG.callbackThreshold().should.equal(3);
+    CONFIG.callbackThreshold(1).should.equal(3);
   });
 
   it('returns threshold when percentage requested', function() {
     CONFIG.active_users = 25;
     CONFIG.callback_threshold_base = 15;
     CONFIG.threshold_is_percentage = true;
-    CONFIG.callbackThreshold().should.equal(3);
+    CONFIG.callbackThreshold(1).should.equal(3);
   });
 
   it('returns threshold at least 2 when percentage requested', function() {
     CONFIG.active_users = 25;
     CONFIG.callback_threshold_base = 3;
     CONFIG.threshold_is_percentage = true;
-    CONFIG.callbackThreshold().should.equal(2);
+    CONFIG.callbackThreshold(1).should.equal(2);
   });
 
   it('returns adjusted threshold when weight is passed', function() {
@@ -53,7 +53,7 @@ describe('config', function() {
 
   it('returns window size in ms', function() {
     CONFIG.callback_window_ms_base = 10000;
-    CONFIG.callbackWindowMs().should.equal(10000);
+    CONFIG.callbackWindowMs(1).should.equal(10000);
   });
 
   it('returns adjusted window size when weight is passed', function() {


### PR DESCRIPTION
The firebase query was using the default weight. This was possible because the weight parameter was optional everywhere. Now we require it when calling the config accessor methods, so we can't accidentally do this. This fixes #78 